### PR TITLE
This fixes a problem when a data dataref went from a string with data…

### DIFF
--- a/client/extplane-client-qt/extplaneconnection.cpp
+++ b/client/extplane-client-qt/extplaneconnection.cpp
@@ -127,8 +127,10 @@ void ExtPlaneConnection::readClient() {
             return;
         } else { // Handle updates
             QStringList cmd = line.split(" ", QString::SkipEmptyParts);
-            if(cmd.size()==3) {
-                ClientDataRef *ref = dataRefs.value(cmd.value(1));
+            ClientDataRef *ref;
+            if(cmd.size()==3)
+            {
+                ref = dataRefs.value(cmd.value(1));
                 if(ref) {
                     if (cmd.value(0)=="ufa" || cmd.value(0)=="uia"){
                         // Array dataref
@@ -149,7 +151,15 @@ void ExtPlaneConnection::readClient() {
                 } else {
                     INFO << "Ref not subscribed " << cmd.value(2);
                 }
+            } else if(cmd.size()==2)    // Might be a data dataref being set to a null string
+            {
+                ref = dataRefs.value(cmd.value(1));
+                if (ref && cmd.value(0)=="ub")
+                {
+                    ref->updateValue(QString(""));  // If this is just a null data dataref then update it to a null string
+                }
             }
+
         }
     }
 }


### PR DESCRIPTION
… to a null string

the client dataref was not getting updated. It was caused by the code always looking
for an input from ExtPlane with three arguements. In the case of a null string
there will only be two arguments.