### PR TITLE
This should fix the missing Windows builds

### DIFF
--- a/extplane-server/extplane-server.pro
+++ b/extplane-server/extplane-server.pro
@@ -4,7 +4,7 @@ CONFIG += staticlib c++11
 include(../common.pri)
 
 # Needed for windows mxe build (hope this doesn't break anything..)
-# DESTDIR = $$PWD
+DESTDIR = $$PWD
 # Yes - it breaks shadow build. Fix the mxe build.
 
 QT       += core network


### PR DESCRIPTION
This should fix the missing win.xpl and extplane-transformer.exe in the final build.
Relates to https://github.com/vranki/ExtPlane/issues/74