### PR TITLE
Fix IntArrayDataref bug

### DIFF
--- a/extplane-server/datarefs/intarraydataref.cpp
+++ b/extplane-server/datarefs/intarraydataref.cpp
@@ -72,6 +72,7 @@ void IntArrayDataRef::setValue(QString &newValue) {
 void IntArrayDataRef::setLength(int newLength)
 {
     Q_ASSERT(newLength > 0);
+    _values.resize(newLength);
     std::fill(_values.begin(), _values.end(), -9999);
     if(_valueArray) delete[] _valueArray;
     _valueArray = new int[newLength];


### PR DESCRIPTION
_values was not resized correctly when IntArrayDataRef::setLength() was called which lead into a crash on IntArrayDataRef::updateValue() call
Fixed